### PR TITLE
scripts/fips_crypto_hmac.sh: Unbreak FIPS with Bash 5

### DIFF
--- a/scripts/fips_crypto_hmac.sh
+++ b/scripts/fips_crypto_hmac.sh
@@ -46,7 +46,7 @@ if [ $retval -ne 0 ]; then
 	exit 1
 fi
 
-declare -A array
+declare -a array
 
 # FOR GENERIC CRYPTO FILES                         #awk fields to cut
 array[0]=".text first_crypto_text last_crypto_text \$5 \$6"


### PR DESCRIPTION
```
FIPS (CONFIG_CRYPTO_FIPS) compares a build-time and runtime digest
during initialization as part of its integrity check. However, the
script generating the build-time digest relied on iteration order of
bash associative arrays, which changed in newer Bash versions, causing
the digest to change. This caused features which relied on FIPS, such
as Full Device Encryption, to fail and cause a kernel panic.

Use a regular array instead of an associative array to fix the
iteration order.
```

If you're using the Revolution Remix kernel as upstream let me know and I can submit there instead.

Will also submit to Lineage supported kernels as soon as they figure out the problem with my Gerrit account. There they worked around this problem by [disabling CONFIG_CRYPTO_FIPS entirely](https://review.lineageos.org/c/LineageOS/android_kernel_samsung_msm8974/+/241236).

Thanks!